### PR TITLE
Add link checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,26 @@
+name: Check links
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.9'
+        architecture: 'x64'
+
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install -r requirements.txt
+
+    - name: Check links
+      run: |
+        # This will not make anything fail on build, but at least we will know
+        pytest -s

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/2023-24/year-2/t2
 docs/2023-24/year-2/t3
 docs/2023-24/research-trip
 docs/assets/images/zz
+*.log

--- a/links.sh
+++ b/links.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+mkdocs-linkcheck docs -r --exclude assets -v -l> tests/out.log 2>tests/err.log

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ mkdocs-macros-plugin
 mkdocs-exclude
 mistune
 mkdocs-open-in-new-tab
+mkdocs-linkcheck
+pytest
 #mkdocs-print-site-plugin
 #mkdocs-plugin-tags
 #mkdocs-with-pdf

--- a/tests/links/test_links.py
+++ b/tests/links/test_links.py
@@ -1,0 +1,13 @@
+import pytest
+import subprocess
+import os
+
+def test_links():
+    out = 0
+    try:
+        out = subprocess.call([os.path.join(os.getcwd(), "links.sh")])
+    except:
+        pass
+
+    print (out)
+    assert out == 0


### PR DESCRIPTION
This adds a local test to run with `pytest` and an automated workflow on github for checks (separate from that of the build).

To test locally:

(First time only) Install requirements:

```
pip install -r requirements.txt
chmod +x links.sh
```

Then:

```
pytest -s
```

If tests don't pass, you can check output in the logs in the `tests` folder.