### PR TITLE
Fix material version to 9.1 and material extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs
-mkdocs-material>=8
-mkdocs-material-extensions
+mkdocs-material==9.1
+mkdocs-material-extensions==1.1
 mkdocs-macros-plugin
 mkdocs-exclude
 mistune


### PR DESCRIPTION
This fixes temporarily the issue with emoji deprecation warnings as show here: https://github.com/fablabbcn/mdef-docs/issues/8

We should update the `mkdocs.yml` to comply with latest mkdocs-material-extensions and be future proof.